### PR TITLE
LUA-989 Support for headers with underscores

### DIFF
--- a/lib/resty/http.lua
+++ b/lib/resty/http.lua
@@ -306,8 +306,8 @@ local function _receive_status(sock)
 end
 
 
-local function _receive_headers(sock)
-    local headers = http_headers.new()
+local function _receive_headers(sock, opt)
+    local headers = http_headers:new(opt)
 
     repeat
         local line, err = sock:receive("*l")
@@ -494,9 +494,9 @@ local function _read_body(res)
 end
 
 
-local function _trailer_reader(sock)
+local function _trailer_reader(sock, opt)
     return co_wrap(function()
-        co_yield(_receive_headers(sock))
+        co_yield(_receive_headers(sock, opt))
     end)
 end
 
@@ -563,7 +563,7 @@ function _M.send_request(self, params)
 
     local sock = self.sock
     local body = params.body
-    local headers = http_headers.new()
+    local headers = http_headers:new(params)
 
     local params_headers = params.headers
     if params_headers then
@@ -655,7 +655,7 @@ function _M.read_response(self, params)
     end
 
 
-    local res_headers, err = _receive_headers(sock)
+    local res_headers, err = _receive_headers(sock, params)
     if not res_headers then
         return nil, err
     end
@@ -695,7 +695,7 @@ function _M.read_response(self, params)
     end
 
     if res_headers["Trailer"] then
-        trailer_reader, err = _trailer_reader(sock)
+        trailer_reader, err = _trailer_reader(sock, params)
     end
 
     if err then

--- a/lib/resty/http_headers.lua
+++ b/lib/resty/http_headers.lua
@@ -23,7 +23,7 @@ end
 -- headers["Content-Length"]
 function _M.new(self, opt)
     local mt = {
-        allow_underscores = opt and opt.allow_underscores or false,
+        header_names_unchanged = opt and opt.header_names_unchanged or false,
         normalised = {},
     }
 
@@ -47,7 +47,7 @@ function _M.new(self, opt)
         local k_normalised = str_lower(k_hyphened)
 
         if not mt.normalised[k_normalised] then
-            local header_name = mt.allow_underscores and k or  k_hyphened
+            local header_name = mt.header_names_unchanged and k or k_hyphened
             mt.normalised[k_normalised] = header_name
             rawset(t, header_name, v)
         else

--- a/lib/resty/http_headers.lua
+++ b/lib/resty/http_headers.lua
@@ -1,8 +1,8 @@
 local   rawget, rawset, setmetatable =
-        rawget, rawset, setmetatable
+rawget, rawset, setmetatable
 
-local str_find, str_lower, str_sub =
-      string.find, string.lower, string.sub
+local str_lower, str_gsub =
+string.lower, string.gsub
 
 
 local _M = {
@@ -11,27 +11,7 @@ local _M = {
 
 
 local function hyphenate(k)
-    local k_hyphened = ""
-    local match = false
-    local prev_pos = 0
-
-    repeat
-        local pos = str_find(k, "_", prev_pos, true)
-        if pos then
-            match = true
-            k_hyphened =  k_hyphened .. str_sub(k, prev_pos, pos - 1) .. "-"
-        elseif match == false then
-            -- Didn't find an underscore and first check
-            return k
-        else
-            -- No more underscores, append the rest of the key
-            k_hyphened = k_hyphened .. str_sub(k, prev_pos)
-            break
-        end
-        prev_pos = pos + 1
-    until not pos
-
-    return k_hyphened
+    return str_gsub(k, "_", "-")
 end
 
 
@@ -41,8 +21,9 @@ end
 -- headers.content_length
 -- headers["content-length"]
 -- headers["Content-Length"]
-function _M.new(self)
+function _M.new(self, opt)
     local mt = {
+        allow_underscores = opt and opt.allow_underscores or false,
         normalised = {},
     }
 
@@ -66,8 +47,9 @@ function _M.new(self)
         local k_normalised = str_lower(k_hyphened)
 
         if not mt.normalised[k_normalised] then
-            mt.normalised[k_normalised] = k_hyphened
-            rawset(t, k_hyphened, v)
+            local header_name = mt.allow_underscores and k or  k_hyphened
+            mt.normalised[k_normalised] = header_name
+            rawset(t, header_name, v)
         else
             rawset(t, mt.normalised[k_normalised], v)
         end


### PR DESCRIPTION
Added an option to allow underscores in the headers. 
This feature can be turned on using `http:send_request(params)` and `http:read_response(params)` with `params.header_names_unchanged = true`.